### PR TITLE
Remove static horizontal validity and update HR logic

### DIFF
--- a/client/pages/DownloadReport.tsx
+++ b/client/pages/DownloadReport.tsx
@@ -3101,7 +3101,6 @@ export default function DownloadReport() {
                         applicable: pinchTests.length > 0,
                       });
 
-
                       // Dynamic lift HR fluctuation check — pass if any dynamic lift (low/mid/high) shows postHR > preHR
                       const dynamicLifts = liftTests.filter((test) => {
                         const n = (test.testName || "").toLowerCase();
@@ -3113,19 +3112,20 @@ export default function DownloadReport() {
                         );
                       });
 
-                      const hrConsistent = dynamicLifts.length > 0
-                        ? dynamicLifts.some((test) => {
-                            const preHR =
-                              test.leftMeasurements?.preHeartRate ??
-                              test.rightMeasurements?.preHeartRate ??
-                              0;
-                            const postHR =
-                              test.leftMeasurements?.postHeartRate ??
-                              test.rightMeasurements?.postHeartRate ??
-                              0;
-                            return postHR > preHR;
-                          })
-                        : null; // Not applicable if no dynamic lifts found
+                      const hrConsistent =
+                        dynamicLifts.length > 0
+                          ? dynamicLifts.some((test) => {
+                              const preHR =
+                                test.leftMeasurements?.preHeartRate ??
+                                test.rightMeasurements?.preHeartRate ??
+                                0;
+                              const postHR =
+                                test.leftMeasurements?.postHeartRate ??
+                                test.rightMeasurements?.postHeartRate ??
+                                0;
+                              return postHR > preHR;
+                            })
+                          : null; // Not applicable if no dynamic lifts found
 
                       crosschecks.push({
                         name: "Dynamic lift HR fluctuation",

--- a/client/pages/ReviewReport.tsx
+++ b/client/pages/ReviewReport.tsx
@@ -2815,7 +2815,6 @@ export default function ReviewReport() {
                           applicable: pinchTests.length > 0,
                         });
 
-
                         // Dynamic lift HR fluctuation check — pass if any dynamic lift (low/mid/high) shows postHR > preHR
                         const dynamicLifts = liftTests.filter((test: any) => {
                           const n = (test.testName || "").toLowerCase();
@@ -2827,19 +2826,20 @@ export default function ReviewReport() {
                           );
                         });
 
-                        const hrConsistent = dynamicLifts.length > 0
-                          ? dynamicLifts.some((test: any) => {
-                              const preHR =
-                                test.leftMeasurements?.preHeartRate ??
-                                test.rightMeasurements?.preHeartRate ??
-                                0;
-                              const postHR =
-                                test.leftMeasurements?.postHeartRate ??
-                                test.rightMeasurements?.postHeartRate ??
-                                0;
-                              return postHR > preHR;
-                            })
-                          : null; // Not applicable if no dynamic lifts found
+                        const hrConsistent =
+                          dynamicLifts.length > 0
+                            ? dynamicLifts.some((test: any) => {
+                                const preHR =
+                                  test.leftMeasurements?.preHeartRate ??
+                                  test.rightMeasurements?.preHeartRate ??
+                                  0;
+                                const postHR =
+                                  test.leftMeasurements?.postHeartRate ??
+                                  test.rightMeasurements?.postHeartRate ??
+                                  0;
+                                return postHR > preHR;
+                              })
+                            : null; // Not applicable if no dynamic lifts found
 
                         crosschecks.push({
                           name: "Dynamic lift HR fluctuation",


### PR DESCRIPTION
## Purpose

Based on user requirements, this PR addresses two key changes to the consistency crosscheck table:

1. **Remove static horizontal validity check**: The user requested removal of the "Static horizontal validity" crosscheck from both review and download report pages
2. **Update dynamic lift HR fluctuation logic**: The user wanted the heart rate check to pass if ANY of the 3 dynamic lifts (low, mid, high) shows post-heart rate higher than pre-heart rate, rather than requiring all lifts to meet certain criteria

## Code changes

### Removed Features
- **Static horizontal validity crosscheck**: Completely removed the logic that filtered for horizontal/static/grip tests and validated CV values ≤ 12%

### Updated Features  
- **Dynamic lift HR fluctuation logic**:
  - Changed from checking ALL lift tests to filtering only dynamic lifts (low/mid/high/dynamic)
  - Updated logic from `every()` to `some()` - now passes if ANY dynamic lift shows postHR > preHR
  - Simplified heart rate comparison to just check if post > pre (removed complex range validation)
  - Updated description to clarify it applies to "any dynamic lift: low, mid or high"
  - Changed applicability check to use `dynamicLifts.length` instead of all `liftTests.length`

### Technical Details
- Applied changes to both `ReviewReport.tsx` and `DownloadReport.tsx` for consistency
- Used nullish coalescing operator (`??`) instead of logical OR (`||`) for cleaner null handling
- Minor text formatting fix in claimant history fallback textTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 13`

🔗 [Edit in Builder.io](https://builder.io/app/projects/0e43026843ef4a17ae8647d56b599e34/zenith-verse)

👀 [Preview Link](https://0e43026843ef4a17ae8647d56b599e34-zenith-verse.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>0e43026843ef4a17ae8647d56b599e34</projectId>-->
<!--<branchName>zenith-verse</branchName>-->