### PR TITLE
Add norm values and percentage displays for left/right tests

### DIFF
--- a/client/pages/TestData.tsx
+++ b/client/pages/TestData.tsx
@@ -1026,7 +1026,10 @@ export default function TestData() {
     return Math.max(0, Math.round(deficiency * 100) / 100); // Only show positive deficiencies
   };
 
-  const calculatePercentOfNorm = (average: number, normValue: number): number => {
+  const calculatePercentOfNorm = (
+    average: number,
+    normValue: number,
+  ): number => {
     if (!normValue || normValue <= 0) return 0;
     const pct = (average / normValue) * 100;
     return Math.round(pct * 100) / 100;
@@ -1503,26 +1506,35 @@ export default function TestData() {
                         </div>
                       </div>
                     )}
-                    {currentTest.normLevel === "yes" && getNormForSide("left") > 0 && (
-                      <>
-                        <div className="bg-blue-400 text-white p-3 rounded text-center">
-                          <div className="text-sm">{isRangeOfMotionTest ? "Primary Norm" : "Left Norm"}</div>
-                          <div className="text-xl font-bold">
-                            {getNormForSide("left")} {getUnitSuffix()}
+                    {currentTest.normLevel === "yes" &&
+                      getNormForSide("left") > 0 && (
+                        <>
+                          <div className="bg-blue-400 text-white p-3 rounded text-center">
+                            <div className="text-sm">
+                              {isRangeOfMotionTest
+                                ? "Primary Norm"
+                                : "Left Norm"}
+                            </div>
+                            <div className="text-xl font-bold">
+                              {getNormForSide("left")} {getUnitSuffix()}
+                            </div>
                           </div>
-                        </div>
-                        <div className="bg-blue-400 text-white p-3 rounded text-center">
-                          <div className="text-sm">{isRangeOfMotionTest ? "Primary % of Norm" : "Left % of Norm"}</div>
-                          <div className="text-xl font-bold">
-                            {calculatePercentOfNorm(
-                              calculateAverage(currentTest.leftMeasurements),
-                              getNormForSide("left"),
-                            )}
-                            %
+                          <div className="bg-blue-400 text-white p-3 rounded text-center">
+                            <div className="text-sm">
+                              {isRangeOfMotionTest
+                                ? "Primary % of Norm"
+                                : "Left % of Norm"}
+                            </div>
+                            <div className="text-xl font-bold">
+                              {calculatePercentOfNorm(
+                                calculateAverage(currentTest.leftMeasurements),
+                                getNormForSide("left"),
+                              )}
+                              %
+                            </div>
                           </div>
-                        </div>
-                      </>
-                    )}
+                        </>
+                      )}
                   </div>
                 </CardContent>
               </Card>
@@ -1717,26 +1729,35 @@ export default function TestData() {
                         </div>
                       </div>
                     )}
-                    {currentTest.normLevel === "yes" && getNormForSide("right") > 0 && (
-                      <>
-                        <div className="bg-blue-400 text-white p-3 rounded text-center">
-                          <div className="text-sm">{isRangeOfMotionTest ? "Secondary Norm" : "Right Norm"}</div>
-                          <div className="text-xl font-bold">
-                            {getNormForSide("right")} {getUnitSuffix()}
+                    {currentTest.normLevel === "yes" &&
+                      getNormForSide("right") > 0 && (
+                        <>
+                          <div className="bg-blue-400 text-white p-3 rounded text-center">
+                            <div className="text-sm">
+                              {isRangeOfMotionTest
+                                ? "Secondary Norm"
+                                : "Right Norm"}
+                            </div>
+                            <div className="text-xl font-bold">
+                              {getNormForSide("right")} {getUnitSuffix()}
+                            </div>
                           </div>
-                        </div>
-                        <div className="bg-blue-400 text-white p-3 rounded text-center">
-                          <div className="text-sm">{isRangeOfMotionTest ? "Secondary % of Norm" : "Right % of Norm"}</div>
-                          <div className="text-xl font-bold">
-                            {calculatePercentOfNorm(
-                              calculateAverage(currentTest.rightMeasurements),
-                              getNormForSide("right"),
-                            )}
-                            %
+                          <div className="bg-blue-400 text-white p-3 rounded text-center">
+                            <div className="text-sm">
+                              {isRangeOfMotionTest
+                                ? "Secondary % of Norm"
+                                : "Right % of Norm"}
+                            </div>
+                            <div className="text-xl font-bold">
+                              {calculatePercentOfNorm(
+                                calculateAverage(currentTest.rightMeasurements),
+                                getNormForSide("right"),
+                              )}
+                              %
+                            </div>
                           </div>
-                        </div>
-                      </>
-                    )}
+                        </>
+                      )}
                   </div>
                 </CardContent>
               </Card>


### PR DESCRIPTION
## Purpose

The user requested to display norm values and percentage of norm calculations for both left and right side tests. They wanted these values shown prominently before the deficiency data in the test interface, with separate displays for left norm/left % of norm and right norm/right % of norm to avoid duplication.

## Code changes

- **Added new interface fields**: `valueToBeTestedNumberLeft` and `valueToBeTestedNumberRight` to the TestData interface for side-specific norm values
- **Implemented helper functions**:
  - `calculatePercentOfNorm()`: Calculates percentage of norm based on average vs norm value
  - `getNormForSide()`: Retrieves norm value for specified side (left/right) with fallback logic
  - `getUnitSuffix()`: Returns appropriate unit suffix for display
- **Added UI components**: Blue cards displaying norm values and percentage of norm for both left and right sides
- **Conditional rendering**: Shows norm displays only when `normLevel === "yes"` and norm values are greater than 0
- **Dynamic labeling**: Uses different labels for range of motion tests (Primary/Secondary) vs regular tests (Left/Right)To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 19`

🔗 [Edit in Builder.io](https://builder.io/app/projects/1f818e316cb744f78710811e8ca92367/pixel-den)

👀 [Preview Link](https://1f818e316cb744f78710811e8ca92367-pixel-den.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>1f818e316cb744f78710811e8ca92367</projectId>-->
<!--<branchName>pixel-den</branchName>-->