### PR TITLE
Extract conclusion content from referral questions data

### DIFF
--- a/client/pages/DownloadReport.tsx
+++ b/client/pages/DownloadReport.tsx
@@ -2061,9 +2061,13 @@ export default function DownloadReport() {
         <div style="margin-top: 30px;">
             <div style="margin-bottom: 20px;">
               ${(() => {
-                const conclusionQuestion = referralQuestionsData?.questions?.find(
-                  (qa) => qa && qa.question && qa.question.toLowerCase().includes("conclusion"),
-                );
+                const conclusionQuestion =
+                  referralQuestionsData?.questions?.find(
+                    (qa) =>
+                      qa &&
+                      qa.question &&
+                      qa.question.toLowerCase().includes("conclusion"),
+                  );
                 if (conclusionQuestion?.answer) {
                   const safe = String(conclusionQuestion.answer)
                     .replace(/&/g, "&amp;")

--- a/client/pages/ReviewReport.tsx
+++ b/client/pages/ReviewReport.tsx
@@ -1777,12 +1777,17 @@ export default function ReviewReport() {
                 <div className="space-y-4 text-sm">
                   {/* Static Conclusion */}
                   {(() => {
-                    const conclusion = reportData.referralQuestionsData?.questions?.find(
-                      (qa: any) => qa?.question && qa.question.toLowerCase().includes("conclusion"),
-                    )?.answer;
+                    const conclusion =
+                      reportData.referralQuestionsData?.questions?.find(
+                        (qa: any) =>
+                          qa?.question &&
+                          qa.question.toLowerCase().includes("conclusion"),
+                      )?.answer;
                     if (!conclusion) return null;
                     return (
-                      <p className="text-sm text-gray-700 leading-relaxed whitespace-pre-line">{conclusion}</p>
+                      <p className="text-sm text-gray-700 leading-relaxed whitespace-pre-line">
+                        {conclusion}
+                      </p>
                     );
                   })()}
 


### PR DESCRIPTION
## Purpose
The user requested to ensure that the conclusion sections in both ReviewReport and DownloadReport pages extract their content from the referral question step conclusion, rather than using static hardcoded text.

## Code changes
- **ReviewReport.tsx**: Replaced static conclusion text with dynamic extraction from `reportData.referralQuestionsData.questions` array, finding questions containing "conclusion" in the title
- **DownloadReport.tsx**: Updated the PDF generation template to dynamically extract conclusion content from `referralQuestionsData.questions` with proper HTML escaping for safe rendering
- Both implementations include fallback handling when no conclusion question is found
- Added proper text formatting with `whitespace-pre-line` for ReviewReport and HTML `<br/>` conversion for DownloadReportTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 23`

🔗 [Edit in Builder.io](https://builder.io/app/projects/3d3e34a411a44f9cbcca75ce6063fa8f/pulse-realm)

👀 [Preview Link](https://3d3e34a411a44f9cbcca75ce6063fa8f-pulse-realm.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>3d3e34a411a44f9cbcca75ce6063fa8f</projectId>-->
<!--<branchName>pulse-realm</branchName>-->