### PR TITLE
Show Action instead of Side for push-pull-cart tests

### DIFF
--- a/client/pages/ReviewReport.tsx
+++ b/client/pages/ReviewReport.tsx
@@ -7006,7 +7006,7 @@ export default function ReviewReport() {
                                             Trial:
                                           </th>
                                           <th className="border border-gray-400 border-r-gray-400 p-2">
-                                            Side:
+                                            {testType === "push-pull-cart" ? "Action:" : "Side:"}
                                           </th>
                                           <th className="border border-gray-400 border-r-gray-400 p-2">
                                             Weight/Plane:
@@ -7047,7 +7047,9 @@ export default function ReviewReport() {
                                                     trialIndex + 1}
                                                 </td>
                                                 <td className="border border-gray-400 p-2 text-center">
-                                                  {trial.side || "Both"}
+                                                  {testType === "push-pull-cart"
+                                                    ? trial.action || ""
+                                                    : trial.side || "Both"}
                                                 </td>
                                                 <td className="border border-gray-400 p-2 text-center">
                                                   {formatParam(trial.weight) ||

--- a/firebase/functions/routes/generateClaimantReport.js
+++ b/firebase/functions/routes/generateClaimantReport.js
@@ -2857,7 +2857,7 @@ async function addCardioDocxContent(children, test) {
   }
 }
 
-function buildMTMTestBlockTable(testName, testData, trials = []) {
+function buildMTMTestBlockTable(testName, testData, trials = [], testType = "") {
   // Colors/styling similar to screenshot
   const PANEL_HEADER_FILL = "FFFF99"; // pale yellow
   const GRID_HEADER_FILL = "F3F4F6"; // light gray
@@ -2902,7 +2902,7 @@ function buildMTMTestBlockTable(testName, testData, trials = []) {
   // Grid header
   const headers = [
     "Trial",
-    "Side",
+    testType === "push-pull-cart" ? "Action" : "Side",
     "Weight/Plane",
     "Distance/Posture",
     "Reps",
@@ -2954,7 +2954,7 @@ function buildMTMTestBlockTable(testName, testData, trials = []) {
 
     const cells = [
       trial.trial || i + 1,
-      trial.side || "Both",
+      testType === "push-pull-cart" ? trial.action || "" : trial.side || "Both",
       trial.weight?.value ?? trial.plane ?? "",
       trial.distance?.value ?? trial.position ?? "",
       Number.isFinite(reps) ? reps : "",
@@ -3592,7 +3592,7 @@ async function generateMTMContentDocx(mtmData, mainTestData) {
     });
 
     // Add test table
-    rightCol.push(buildMTMTestBlockTable(testName, testData, trials));
+    rightCol.push(buildMTMTestBlockTable(testName, testData, trials, testType));
 
     // Heart Rate
     const { preHR, postHR } = extractHeartRateForMTM(

--- a/firebase/functions/routes/generateExecutiveSummaryClaimantReport.js
+++ b/firebase/functions/routes/generateExecutiveSummaryClaimantReport.js
@@ -2275,7 +2275,7 @@ async function addCardioDocxContent(children, test) {
   }
 }
 
-function buildMTMTestBlockTable(testName, testData, trials = []) {
+function buildMTMTestBlockTable(testName, testData, trials = [], testType = "") {
   // Colors/styling similar to screenshot
   const PANEL_HEADER_FILL = "FFFF99"; // pale yellow
   const GRID_HEADER_FILL = "F3F4F6"; // light gray
@@ -2320,7 +2320,7 @@ function buildMTMTestBlockTable(testName, testData, trials = []) {
   // Grid header
   const headers = [
     "Trial",
-    "Side",
+    testType === "push-pull-cart" ? "Action" : "Side",
     "Weight/Plane",
     "Distance/Posture",
     "Reps",
@@ -2372,7 +2372,7 @@ function buildMTMTestBlockTable(testName, testData, trials = []) {
 
     const cells = [
       trial.trial || i + 1,
-      trial.side || "Both",
+      testType === "push-pull-cart" ? trial.action || "" : trial.side || "Both",
       trial.weight?.value ?? trial.plane ?? "",
       trial.distance?.value ?? trial.position ?? "",
       Number.isFinite(reps) ? reps : "",
@@ -3010,7 +3010,7 @@ async function generateMTMContentDocx(mtmData, mainTestData) {
     });
 
     // Add test table
-    rightCol.push(buildMTMTestBlockTable(testName, testData, trials));
+    rightCol.push(buildMTMTestBlockTable(testName, testData, trials, testType));
 
     // Heart Rate
     const { preHR, postHR } = extractHeartRateForMTM(


### PR DESCRIPTION
### Summary
This PR fixes the review report and generated claimant reports to display "Action" (and the corresponding `action` field value) instead of "Side" for push-pull-cart test type entries.

### Problem
When a test of type `push-pull-cart` was recorded, the review report and the generated DOCX reports (claimant report and executive summary claimant report) were still showing the column header "Side" and rendering `trial.side` data. The push-pull-cart test uses an `action` field instead of a `side` field, so the correct label and value were not being displayed in any of the report outputs.

### Solution
Added a `testType` check wherever the "Side" column header and cell value are rendered. When `testType === "push-pull-cart"`, the header reads "Action" and the cell displays `trial.action`; otherwise, the original "Side" / `trial.side` behavior is preserved.

### Key Changes
- **`client/pages/ReviewReport.tsx`**: Updated the table header and cell to conditionally render `"Action:"` / `trial.action` for `push-pull-cart`, falling back to `"Side:"` / `trial.side || "Both"` for all other test types.
- **`firebase/functions/routes/generateClaimantReport.js`**: Added `testType` parameter to `buildMTMTestBlockTable` and applied the same conditional logic to the grid header and trial cell data.
- **`firebase/functions/routes/generateExecutiveSummaryClaimantReport.js`**: Applied the identical `testType` parameter and conditional logic to the executive summary report's `buildMTMTestBlockTable` function.


---

<a href="https://builder.io/app/projects/0b492a5bad7848a0831965ee09b5a8ae/multi-haven-kl46ctuh"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://0b492a5bad7848a0831965ee09b5a8ae-multi-haven-kl46ctuh_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 154`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>0b492a5bad7848a0831965ee09b5a8ae</projectId>-->
<!--<branchName>multi-haven-kl46ctuh</branchName>-->